### PR TITLE
changes to make compatible with jsdom 2.0.0-4.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ executing `npm run jsx`. This will save the built file into
 
 ### jsdom
 
-Setting up jsdom ^2.0.0 can be acheived in a couple of lines:
+Setting up jsdom 2.0.0-4.0.1 can be acheived in a couple of lines:
 
 ```javascript
 // file: test/setup.js
@@ -95,8 +95,11 @@ var jsdom = require('jsdom');
 // A super simple DOM ready for React to render into
 // Store this DOM and the window in global scope ready for React to access
 global.document = jsdom.jsdom('<!doctype html><html><body></body></html>');
-global.window = document.parentWindow;
+global.window = document.defaultView;
+global.navigator = window.navigator;
 ```
+
+
 
 We are emulating a browser environment here by setting the global variables
 `document` and `window` as created by `jsdom`. This later allows React to render
@@ -250,7 +253,7 @@ $ npm test
 
 
   Todo-item component
-    ✓ <input> should be of type "checkbox" 
+    ✓ <input> should be of type "checkbox"
 
 
   1 passing (25ms)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Jess Telford <hi@jes.st>",
   "license": "ISC",
   "devDependencies": {
-    "jsdom": "^2.0.0",
+    "jsdom": "^3.1.2",
     "mocha": "^2.1.0",
     "react-tools": "^0.12.1"
   },

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,4 +1,5 @@
 var jsdom = require('jsdom');
 
 global.document = jsdom.jsdom('<!doctype html><html><body></body></html>');
-global.window = document.parentWindow;
+global.window = document.defaultView;
+global.navigator = window.navigator;


### PR DESCRIPTION
When trying to use the code with jsdom v3 or v4, I found that I needed to make some small changes to the setup code.

I also back tested the code against jsdom@2.0.0 and it works as well, so it would appear to be safe to switch to this for better compatibility with newer versions.

global.navigator was needed when I started testing with events, so I included it as well.