### PR TITLE
Update examples to use ES6 syntax and upgrade dependencies.

### DIFF
--- a/common/components/todo-item.js
+++ b/common/components/todo-item.js
@@ -1,39 +1,38 @@
-var React = require('react');
+import React from 'react';
 
-module.exports = React.createClass({
-  displayName: 'TodoItem',
+export default class TodoItem extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { done: props.done };
+  }
 
   /**
    * Lifecycle functions
    **/
-  getInitialState: function() {
-    return { done: this.props.done }
-  },
-
-  componentDidMount: function() {
+  componentDidMount() {
     this.setDone(this.refs.done.getDOMNode().checked);
-  },
+  }
 
-  render: function() {
+  render() {
     return (
       <label>
         <input ref="done" type="checkbox" defaultChecked={this.state.done} onChange={this.onChange} />
         {this.props.name}
       </label>
     );
-  },
+  }
 
   /**
    * Event handlers
    **/
-  onChange: function(event) {
+  onChange(event) {
     this.setDone(event.target.checked);
-  },
+  }
 
   /**
    * Utilities
    **/
-  setDone: function(done) {
+  setDone(done) {
     this.setState({ done: !!done});
   }
-});
+}

--- a/package.json
+++ b/package.json
@@ -1,20 +1,19 @@
 {
   "name": "react-testing-mocha-jsdom",
   "private": true,
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Unit testing React with Mocha and jsdom",
   "scripts": {
-    "test": "mocha --compilers js:babel/register --recursive"
+    "test": "mocha --compilers js:babel-core/register --recursive"
   },
   "author": "Jess Telford <hi@jes.st>",
   "license": "ISC",
-  "devDependencies": {
-    "babel": "^5.1.13",
-    "jsdom": "^2.0.0",
-    "mocha": "^2.1.0",
-    "react-tools": "^0.12.1"
-  },
   "dependencies": {
-    "react": "^0.12.1"
+    "react": "^0.13.3"
+  },
+  "devDependencies": {
+    "babel-core": "^5.4.7",
+    "jsdom": "^6.0.1",
+    "mocha": "^2.2.5"
   }
 }

--- a/test/component/todo-item.js
+++ b/test/component/todo-item.js
@@ -1,29 +1,32 @@
-var React = require('react/addons'),
-    assert = require('assert'),
-    TodoItem = require('../../common/components/todo-item'),
-    TestUtils = React.addons.TestUtils;
+import assert from 'assert';
+import React from 'react/addons';
+import TodoItem from '../../common/components/todo-item';
 
-describe('Todo-item component', function(){
-  before('render and locate element', function() {
-    var renderedComponent = TestUtils.renderIntoDocument(
+const TestUtils = React.addons.TestUtils;
+
+describe('Todo-item component', () => {
+  let inputElement;
+
+  before('render and locate element', () => {
+    const renderedComponent = TestUtils.renderIntoDocument(
       <TodoItem done={false} name="Write Tutorial"/>
     );
 
     // Searching for <input> tag within rendered React component
     // Throws an exception if not found
-    var inputComponent = TestUtils.findRenderedDOMComponentWithTag(
+    const inputComponent = TestUtils.findRenderedDOMComponentWithTag(
       renderedComponent,
       'input'
     );
 
-    this.inputElement = inputComponent.getDOMNode();
+    inputElement = inputComponent.getDOMNode();
   });
 
-  it('<input> should be of type "checkbox"', function() {
-    assert(this.inputElement.getAttribute('type') === 'checkbox');
+  it('<input> should be of type "checkbox"', () => {
+    assert(inputElement.getAttribute('type') === 'checkbox');
   });
 
-  it('<input> should not be checked', function() {
-    assert(this.inputElement.checked === false);
+  it('<input> should not be checked', () => {
+    assert(inputElement.checked === false);
   });
 });

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,4 +1,9 @@
-var jsdom = require('jsdom');
+import jsdom from 'jsdom';
 
 global.document = jsdom.jsdom('<!doctype html><html><body></body></html>');
-global.window = document.parentWindow;
+global.window = document.defaultView;
+global.navigator = window.navigator;
+
+window.addEventListener('load', () => {
+  console.log('JSDom setup completed: document, window and navigator are now on global scope.');
+});


### PR DESCRIPTION
I've rewritten your example to use ES6 syntax (notably imports, exports and arrow functions). Also I've updated it's dependencies, which means it uses React v0.13.3 and JSDom 6.0.1, along with associated API changes.

I'm not sure you want to go this way. You could just refer to my fork instead if you like.
