### PR TITLE
Adding an example using expect-jsx

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+  ],
+  "presets": [
+    "es2015",
+    "react"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -9,19 +9,17 @@
   "author": "Jess Telford <hi@jes.st>",
   "license": "ISC",
   "devDependencies": {
-    "babel-core": "6.5.2",
-    "babel-register": "6.5.2",
+    "babel-core": "6.6.0",
+    "babel-register": "6.6.0",
+    "babel-preset-es2015": "6.6.0",
+    "babel-preset-react": "6.5.0",
     "expect": "^1.14.0",
     "expect-jsx": "^2.3.0",
     "jsdom": "^2.0.0",
     "mocha": "^2.1.0",
-    "react-addons-test-utils": "^0.14.7",
-    "react-tools": "^0.12.1"
+    "react-addons-test-utils": "^0.14.7"
   },
   "dependencies": {
-    "babel-core": "6.6.0",
-    "babel-preset-es2015": "6.6.0",
-    "babel-preset-react": "6.5.0",
-    "react": "0.14.7"
+    "react": "^0.14.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,17 +4,24 @@
   "version": "1.0.0",
   "description": "Unit testing React with Mocha and jsdom",
   "scripts": {
-    "test": "mocha --compilers js:babel/register --recursive"
+    "test": "mocha --compilers js:babel-register --recursive"
   },
   "author": "Jess Telford <hi@jes.st>",
   "license": "ISC",
   "devDependencies": {
-    "babel": "^5.1.13",
+    "babel-core": "6.5.2",
+    "babel-register": "6.5.2",
+    "expect": "^1.14.0",
+    "expect-jsx": "^2.3.0",
     "jsdom": "^2.0.0",
     "mocha": "^2.1.0",
+    "react-addons-test-utils": "^0.14.7",
     "react-tools": "^0.12.1"
   },
   "dependencies": {
-    "react": "^0.12.1"
+    "babel-core": "6.6.0",
+    "babel-preset-es2015": "6.6.0",
+    "babel-preset-react": "6.5.0",
+    "react": "0.14.7"
   }
 }

--- a/test/component/todo-item-expectjsx.js
+++ b/test/component/todo-item-expectjsx.js
@@ -1,5 +1,4 @@
 import React from 'react/addons';
-import assert from 'assert';
 import expectJSX from 'expect-jsx';
 import expect from 'expect';
 import TodoItem from '../../common/components/todo-item';

--- a/test/component/todo-item-expectjsx.js
+++ b/test/component/todo-item-expectjsx.js
@@ -1,0 +1,26 @@
+import React from 'react/addons';
+import assert from 'assert';
+import expectJSX from 'expect-jsx';
+import expect from 'expect';
+import TodoItem from '../../common/components/todo-item';
+
+import {createRenderer, renderIntoDocument, findRenderedDOMComponentWithTag} from 'react-addons-test-utils';
+
+expect.extend(expectJSX);
+
+describe('Todo-item component', function(){
+  it('<input> should not be checked - using expect-jsx', () => {
+    let renderer = createRenderer();
+    renderer.render(<TodoItem done={false} name="Write Tutorial"/>);
+    let actualElement = renderer.getRenderOutput();
+
+    const expectedElement = <label>
+      <input ref="done"
+        defaultChecked={false}
+        onChange={()=>{}}
+        type="checkbox"/>
+      Write Tutorial
+    </label>;
+    expect(actualElement).toEqualJSX(expectedElement);
+  });
+});

--- a/test/component/todo-item-expectjsx.js
+++ b/test/component/todo-item-expectjsx.js
@@ -4,7 +4,7 @@ import expectJSX from 'expect-jsx';
 import expect from 'expect';
 import TodoItem from '../../common/components/todo-item';
 
-import {createRenderer, renderIntoDocument, findRenderedDOMComponentWithTag} from 'react-addons-test-utils';
+import {createRenderer} from 'react-addons-test-utils';
 
 expect.extend(expectJSX);
 


### PR DESCRIPTION
I updated the babel library which now is called babel-core and added only the modules we need.

And added an example using expect-jsx https://github.com/algolia/expect-jsx

Added also .babelrc cause im using es6 syntax. I saw in another pull request someone already change the existing tests to es6 so if you want I can do a rebase when that one is merged.
